### PR TITLE
Replacing Secret token to Github internal Token

### DIFF
--- a/.github/workflows/Kontrol.yml
+++ b/.github/workflows/Kontrol.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Depo Kontrolü
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PAT_TOKEN }}  # PAT kullan
+          token: ${{ github.token }}  # PAT kullan
 
       - name: Python 3.11.8 Yükle
         uses: actions/setup-python@v5


### PR DESCRIPTION
Removed secret PAT and replaced to github variable for a temp repo Token ( one time use token and changes everytime the workflow is executed )